### PR TITLE
`tap-tap` -> `ruby-tap`

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -27,14 +27,14 @@ import esbuild from "esbuild"
   await Promise.all[
     esbuild.build({
       ...defaultConfig,
-      outfile: "dist/bundle/tap-tap.common.js",
+      outfile: "dist/bundle/ruby-tap.common.js",
       format: "cjs",
       minify: true,
     }),
 
     esbuild.build({
       ...defaultConfig,
-      outfile: "dist/bundle/tap-tap.module.js",
+      outfile: "dist/bundle/ruby-tap.module.js",
       format: "esm",
       minify: true,
     }),


### PR DESCRIPTION
## Status

Ready

## Related Issue(s)

* closes / fixes -

## Additional Notes

Hey it's me again. I just tried to install the package from npm, but seems like the distributed version contains the old `tap-tap` files in the dist/ resulting in a failing import 🙃 

```
❯ ls node_modules/ruby-tap/dist/bundle/
tap-tap.common.js      tap-tap.common.js.map  tap-tap.module.js      tap-tap.module.js.map
```

